### PR TITLE
feat(postgres): add image with pgvector, postgis and pluggable extensions

### DIFF
--- a/postgres.Dockerfile
+++ b/postgres.Dockerfile
@@ -1,0 +1,45 @@
+# syntax=docker/dockerfile:1.22-labs
+ARG PLATFORMS=linux/amd64,linux/arm64
+
+# renovate datasource=docker depName=postgres versioning=docker
+ARG POSTGRES_VERSION=17.10
+
+FROM postgres:${POSTGRES_VERSION}-bookworm
+
+# Extra space-separated apt packages to bake in on top of the bundled
+# extensions. The official image already configures the PGDG apt repo and
+# exports PG_MAJOR, so any versioned extension package can be added, e.g.:
+#   --build-arg EXTRA_EXTENSIONS="postgresql-17-cron postgresql-17-hll"
+ARG EXTRA_EXTENSIONS=""
+
+LABEL org.opencontainers.image.title="postgres" \
+      org.opencontainers.image.description="PostgreSQL bundled with pgvector and PostGIS, with a drop-in mechanism to add more extensions" \
+      org.opencontainers.image.source="https://github.com/jaysonsantos/bunderwar"
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install --no-install-recommends -y \
+        postgresql-${PG_MAJOR}-pgvector \
+        postgresql-${PG_MAJOR}-postgis-3 \
+        postgresql-${PG_MAJOR}-postgis-3-scripts \
+        postgresql-${PG_MAJOR}-cron \
+        postgresql-${PG_MAJOR}-timescaledb \
+        postgresql-${PG_MAJOR}-pg-uuidv7 \
+        postgresql-${PG_MAJOR}-pg-ivm \
+        ${EXTRA_EXTENSIONS}; \
+    rm -rf /var/lib/apt/lists/*
+
+# Auto-create the extensions listed in POSTGRES_EXTENSIONS on first cluster init.
+COPY --chmod=755 postgres/initdb/10-create-extensions.sh /docker-entrypoint-initdb.d/10-create-extensions.sh
+
+# Comma- or space-separated list of extensions created when the cluster is first
+# initialised. Override at runtime to enable a different set.
+ENV POSTGRES_EXTENSIONS="vector,postgis,timescaledb,pg_cron,pg_uuidv7,pg_ivm"
+
+# pg_cron and timescaledb must be loaded at server start, so preload them. The
+# official entrypoint passes these same args to the temporary init server too,
+# which is why CREATE EXTENSION works during first-init. pg_cron runs its
+# background worker against cron.database_name (the default "postgres" db); if
+# you set POSTGRES_DB to something else and want pg_cron there, also pass
+# "-c cron.database_name=<db>".
+CMD ["postgres", "-c", "shared_preload_libraries=timescaledb,pg_cron"]

--- a/postgres/initdb/10-create-extensions.sh
+++ b/postgres/initdb/10-create-extensions.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Create the extensions listed in POSTGRES_EXTENSIONS (comma- or space-separated)
+# in the default database when the cluster is first initialised. Adding another
+# extension is just a matter of installing its package (see EXTRA_EXTENSIONS in
+# the Dockerfile) and listing it here or in POSTGRES_EXTENSIONS at runtime.
+set -euo pipefail
+
+extensions="${POSTGRES_EXTENSIONS:-}"
+# Treat commas as separators and collapse to a clean, space-separated list.
+extensions="${extensions//,/ }"
+
+if [ -z "${extensions// /}" ]; then
+    echo "POSTGRES_EXTENSIONS is empty, skipping extension creation"
+    exit 0
+fi
+
+for ext in $extensions; do
+    echo "Creating extension if not exists: ${ext}"
+    psql -v ON_ERROR_STOP=1 \
+        --username "$POSTGRES_USER" \
+        --dbname "${POSTGRES_DB:-$POSTGRES_USER}" \
+        -c "CREATE EXTENSION IF NOT EXISTS \"${ext}\";"
+done


### PR DESCRIPTION
Adds a new `postgres.Dockerfile` built on the official `postgres:17.10-bookworm` base, bundling pgvector, PostGIS, TimescaleDB, pg_cron, pg_uuidv7 and pg_ivm (installed from the PGDG apt repo the base image already configures). An init script auto-runs `CREATE EXTENSION` for everything listed in `POSTGRES_EXTENSIONS` on first cluster init, while an `EXTRA_EXTENSIONS` build arg makes baking in further PGDG packages a one-line change. pg_cron and timescaledb are preloaded via `shared_preload_libraries` (passed through `CMD`), which the official entrypoint also applies to its temporary init server so `CREATE EXTENSION` works during first-init. The image is picked up automatically by `build.py` (tag `postgres-17.10`, both arches) and the version is Renovate-tracked.

All extensions were built and functionally verified locally with podman (hypertable creation, a scheduled cron job, UUIDv7 generation, and an incrementally-maintained view); builds were not run via CI/`docker buildx`, which isn't installed in this environment.